### PR TITLE
Remove GIT_EDITOR from environment before test

### DIFF
--- a/t/20-simple.t
+++ b/t/20-simple.t
@@ -60,7 +60,7 @@ TXT
 $r->run( add => 'readme.txt' );
 
 # unset all editors
-delete @ENV{qw( EDITOR VISUAL )};
+delete @ENV{qw( EDITOR VISUAL GIT_EDITOR )};
 
 SKIP: {
     BEGIN { $tests += 2 }


### PR DESCRIPTION
Currently installation fails at test stage if you have GIT_EDITOR is set in the environment.
This change fixes that...
