### PR TITLE
skip tests if core.editor presents in config

### DIFF
--- a/t/20-simple.t
+++ b/t/20-simple.t
@@ -67,6 +67,9 @@ SKIP: {
     skip "these tests require git >= 1.6.6, but we only have $version", 2
         if Git::Repository->version_lt('1.6.6');
 
+    skip "editor defined directly in .gitconfig", 2
+        if $r->run( config => 'core.editor' );
+
     ok( !eval { $r->run( var => 'GIT_EDITOR' ); 1; }, 'git var GIT_EDITOR' );
     like(
         $@,
@@ -77,7 +80,10 @@ SKIP: {
 
 # with git commit it's not fatal
 BEGIN { $tests += 4 }
-{
+SKIP: {
+    skip "editor defined directly in .gitconfig", 4
+        if $r->run( config => 'core.editor' );
+
     ok( my $cmd = $r->command('commit'), 'git commit' );
     isa_ok( $cmd, 'Git::Repository::Command' );
     my $error = $cmd->stderr->getline;


### PR DESCRIPTION
The tests in question rely on GIT_EDITOR not to be accessible, which is not going to be true if it was configured via 'core.editor'.
