### PR TITLE
Fixed t/40-plugin-log.t 

### DIFF
--- a/t/40-plugin-log.t
+++ b/t/40-plugin-log.t
@@ -100,7 +100,7 @@ chdir $home;
 
 # try a command that fails (fatal)
 BEGIN { $tests += 2 }
-ok( !eval { @log = Git::Repository->log('zlonk') }, q{log('zlonk') failed} );
+ok( !eval { @log = $r->log('zlonk') }, q{log('zlonk') failed} );
 like(
     $@,
     qr/^fatal: ambiguous argument 'zlonk': unknown revision or path not in/,
@@ -109,7 +109,7 @@ like(
 
 # try a command that returns a git error (usage)
 BEGIN { $tests += 2 }
-ok( !eval { @log = Git::Repository->log('--bam') }, q{log('--bam') failed} );
+ok( !eval { @log = $r->log('--bam') }, q{log('--bam') failed} );
 like(
     $@,
     qr/^fatal: unrecognized argument: --bam at/,


### PR DESCRIPTION
Hi,

I think t/40-plugin-log.t try a command that fails (fatal) tests are to need a git repository.
Git::Repository->log doesn't assign a repository path.
It returns "fatal: Not a git repository (or any of the parent directories)".
In addition, if there is a repository in upper directory from the current directory, All tests successful.
