### PR TITLE
potential fix for deep recursion caused by last System::Command

### DIFF
--- a/lib/Git/Repository/Command.pm
+++ b/lib/Git/Repository/Command.pm
@@ -79,7 +79,7 @@ sub _is_git {
 
     # try to run it
     my ( $pid, $in, $out, $err )
-        = __PACKAGE__->spawn( $git, @args, '--version' );
+        = System::Command->spawn( $git, @args, '--version' );
     my $version = <$out>;
 
     # does it really look like git?


### PR DESCRIPTION
It seems that the commit 70861eb19459ae0d5601d70394b18b9df981f2ba in System::Command somehow broke Git::Repository. At lease I get:

Deep recursion on subroutine "Git::Repository::Command::new" at /home/domm/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/System/Command.pm line 145.
Deep recursion on subroutine "Git::Repository::Command::_is_git" at /home/domm/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Git/Repository/Command.pm line 130.
Deep recursion on subroutine "System::Command::spawn" at /home/domm/perl5/perlbrew/perls/perl-5.14.1/lib/site_perl/5.14.1/Git/Repository/Command.pm line 81.

when running t/05-try_git.t (or my code...)

This commit fixes the symptom, but I have no idea if it fixes the problem...
