### PR TITLE
Fix dependencies: remove IPC::Open3

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,8 +12,10 @@ my $builder = Module::Build->new(
         'List::Util' => 0,
         'File::Spec' => 0,
         'File::Path' => 0,
-        'IPC::Open3' => 0,
         'Cwd' => 0,
+        'Carp'       => 0,
+        'IO::Handle' => 0,
+        'Scalar::Util' => 0,
         'System::Command' => '1.05',
     },
     build_requires => {

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Philippe Bruhat (BooK) <book@cpan.org>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.38, CPAN::Meta::Converter version 2.112621",
+   "generated_by" : "Module::Build version 0.4003, CPAN::Meta::Converter version 2.120921",
    "license" : [
       "perl_5"
    ],
@@ -16,21 +16,23 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Test::More" : 0
+            "Test::More" : "0"
          }
       },
       "configure" : {
          "requires" : {
-            "Module::Build" : "0.38"
+            "Module::Build" : "0.40"
          }
       },
       "runtime" : {
          "requires" : {
-            "Cwd" : 0,
-            "File::Path" : 0,
-            "File::Spec" : 0,
-            "IPC::Open3" : 0,
-            "List::Util" : 0,
+            "Carp" : "0",
+            "Cwd" : "0",
+            "File::Path" : "0",
+            "File::Spec" : "0",
+            "IO::Handle" : "0",
+            "List::Util" : "0",
+            "Scalar::Util" : "0",
             "System::Command" : "1.05"
          }
       }

--- a/META.yml
+++ b/META.yml
@@ -5,9 +5,9 @@ author:
 build_requires:
   Test::More: 0
 configure_requires:
-  Module::Build: 0.38
+  Module::Build: 0.40
 dynamic_config: 1
-generated_by: 'Module::Build version 0.38, CPAN::Meta::Converter version 2.112621'
+generated_by: 'Module::Build version 0.4003, CPAN::Meta::Converter version 2.120921'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -36,11 +36,13 @@ provides:
     file: lib/Test/Git.pm
     version: 1.02
 requires:
+  Carp: 0
   Cwd: 0
   File::Path: 0
   File::Spec: 0
-  IPC::Open3: 0
+  IO::Handle: 0
   List::Util: 0
+  Scalar::Util: 0
   System::Command: 1.05
 resources:
   license: http://dev.perl.org/licenses/

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,8 +14,10 @@ WriteMakefile(
         'List::Util' => 0,
         'File::Spec' => 0,
         'File::Path' => 0,
-        'IPC::Open3' => 0,
         'Cwd' => 0,
+        'Carp'       => 0,
+        'IO::Handle' => 0,
+        'Scalar::Util' => 0,
         'System::Command' => '1.05',
     },
     META_MERGE => {

--- a/lib/Git/Repository/Command.pm
+++ b/lib/Git/Repository/Command.pm
@@ -7,7 +7,6 @@ use 5.006;
 use Carp;
 use Cwd qw( cwd );
 use IO::Handle;
-use IPC::Open3 qw( open3 );
 use Scalar::Util qw( blessed );
 use File::Spec;
 use Config;


### PR DESCRIPTION
The code that uses IPC::Open3 is now in System::Command, so IPC::Open3
is not directly needed. So remove IPC::Open3 usage from Git::Repository::Command and meta.

Add other module dependencies that were not specified in meta, even if
they are in the core: Carp, IO::Handle, Scalar::Util.

Module::Build dependency updated to 0.40.
