### PR TITLE
Fix support for overloaded objects.

### DIFF
--- a/lib/Git/Repository/Command.pm
+++ b/lib/Git/Repository/Command.pm
@@ -92,13 +92,32 @@ sub _is_git {
             : undef;
 }
 
+
+sub _extract_special_from_list (&;@) {
+    my $filter = shift;
+
+    my @specials;
+    my @things;
+    for my $thing (@_) {
+        if( $filter->($thing) ) {
+            push @specials, $thing;
+        }
+        else {
+            push @things, $thing;
+        }
+    }
+
+    # Current behavior silently ignores any additional items
+    return($specials[0], @things);
+}
+
 sub new {
     my ( $class, @cmd ) = @_;
 
     # split the args
-    my ($r) = grep { blessed $_ && $_->isa('Git::Repository') } @cmd;
+    my $r;
+    ($r, @cmd) = _extract_special_from_list { blessed $_[0] && $_[0]->isa('Git::Repository') } @cmd;
     my @o = grep { ref eq 'HASH' } @cmd;
-    @cmd = grep { !ref } @cmd;
 
     # keep changes to the environment local
     local %ENV = %ENV;

--- a/t/26-overloaded_objects.t
+++ b/t/26-overloaded_objects.t
@@ -1,0 +1,42 @@
+#!/usr/bin/perl
+
+# Test that we work with stringified path objects like Path::Class.
+
+use strict;
+use warnings;
+
+use lib 't';
+
+use Test::More;
+use Test::Git;
+use File::Temp qw(tempdir);
+use Cwd qw(realpath);
+
+has_git('1.5.0');
+
+plan tests => 3;
+
+# clean up the environment
+delete @ENV{qw( GIT_DIR GIT_WORK_TREE )};
+
+# A class with stringification to test with.
+{
+    package My::Dir;
+    use overload
+      '""'       => sub { $_[0]->{path} },
+      "fallback" => 1;
+
+    sub new {
+        my $class = shift;
+        my $path = shift;
+        return bless { path => $path }, $class;
+    }
+}
+
+
+my $repo_dir = My::Dir->new( tempdir( CLEANUP => 1 ) );
+note( Git::Repository->run( init => $repo_dir ) );
+ok -d "$repo_dir/.git", "git repo initialized";
+my $r = eval { Git::Repository->new( work_tree => $repo_dir ); };
+isa_ok $r, "Git::Repository";
+is $r->work_tree, realpath($repo_dir);


### PR DESCRIPTION
Git::Repository::Command->new would silently filter out all references from the command
arguments, catching things like Path::Class.  The filter looks like it was there to
catch extra Git::Repository objects on the command and ignore them.  I don't agree
with this feature, but its tested in t/20-simple.t and I've emulated it.

The new code removes the Git::Repository objects from the command list explicitly.

For rt.cpan.org 82373
