### PR TITLE
Update docs with example of options hash

### DIFF
--- a/lib/Git/Repository.pm
+++ b/lib/Git/Repository.pm
@@ -300,6 +300,9 @@ sub version_ge {
 
     # start from a repository reachable from the current directory
     $r = Git::Repository->new();
+    
+    # Use a specific git binary on an existing repository
+    $r = Git::Repository->new( git_dir => $gitdir, { git => './bin/git' } );
 
     # or init our own repository first
     Git::Repository->run( init => $dir, ... );


### PR DESCRIPTION
I knew it was possible to specify a 'git' command but couldn't work out how from the docs. Had to read through the code to realise it had to go in a hashref, rather than just being part of the list of passed-in arguments. Hopefully this clarifies that there's an optional "options" hashref.
