### PR TITLE
Show exit status in 'unknown git error' message. Clarify fatal setup code.

### DIFF
--- a/t/24-errors.t
+++ b/t/24-errors.t
@@ -133,7 +133,7 @@ push @tests, (
     },
     {   cmd  => [ exit => 124, { git => $exit, fatal => [ 1 .. 255 ] } ],
         exit => 124,
-        dollar_at => qr/^fatal: unknown git error/,
+        dollar_at => qr/^fatal: unknown git error, exit status 124/,
     },
 
     # setup a repo with some 'fatal' options


### PR DESCRIPTION
Hi. This is a minor tweak. I've opened cases in System::Command to address my main need to have exit status info included in the trace.