### PR TITLE
Fixing failing test on a Mac OS X due to git from Xcode returning a n…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ cover_db
 MYMETA.*
 mess
 setup
+.DS_Store

--- a/t/06-version.t
+++ b/t/06-version.t
@@ -10,10 +10,9 @@ my ($version) = Git::Repository->run('--version') =~ /git version (.*)/g;
 diag "git version $version";
 
 # other versions based on the current one
-($version) = split / /, $version;    # drop "comments"
 my ( @lesser, @greater );
 if ( $version =~ /^[1-9]+(?:\.[0-9]+)*$/ ) {
-    my @version = split /\./, $version;
+    my @version = split /\./, ( split / /, $version )[0];
     for ( 0 .. $#version ) {
         local $" = '.';
         my @v = @version;


### PR DESCRIPTION
…on-standard version. Also ignore the .DS_Store files which get created on OS X