### PR TITLE
Match new error message format in git 2.17.

### DIFF
--- a/t/10-new_fail.t
+++ b/t/10-new_fail.t
@@ -50,7 +50,7 @@ SKIP: {
     );
     like(
         $@,
-        qr/^fatal: Not a git repository/,    # error from git itself
+        qr/^fatal: [nN]ot a git repository/,    # error from git itself
         '... expected error message'
     );
 }


### PR DESCRIPTION
Addressing
```
t/06-version.t ............. # git version 2.17.0.rc1
# git version 2.17.0.rc1
t/06-version.t ............. ok
t/07-version.t ............. ok
t/10-new_fail.t ............ 1/12
#   Failed test '... expected error message'
#   at t/10-new_fail.t line 51.
#                   'fatal: not a git repository (or any parent up to mount point /)
# Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set). at t/10-new_fail.t line 48.
# '
#     doesn't match '(?^:^fatal: Not a git repository)'
# Looks like you failed 1 test of 12.
t/10-new_fail.t ............ Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/12 subtests
```