### PR TITLE
git 2.19 apparently changed its error messages.

### DIFF
--- a/t/24-errors.t
+++ b/t/24-errors.t
@@ -89,7 +89,7 @@ my @tests = (
     {   cmd      => [ checkout => 'does-not-exist' ],
         exit     => 1,
         warnings => [
-            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\.?/,
+            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git/,
         ],
     },
 
@@ -110,12 +110,12 @@ my @tests = (
     {   cmd  => [ checkout => 'does-not-exist', { fatal => [1] } ],
         exit => 1,
         dollar_at =>
-            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\.?/,
+            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git/,
     },
     {   cmd  => [ checkout => 'does-not-exist', { fatal => 1 } ],
         exit => 1,
         dollar_at =>
-            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\.?/,
+            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git/,
     },
     {   cmd      => [ rm => 'does-not-exist', { fatal => -128 } ],
         exit     => 128,

--- a/t/24-errors.t
+++ b/t/24-errors.t
@@ -89,7 +89,7 @@ my @tests = (
     {   cmd      => [ checkout => 'does-not-exist' ],
         exit     => 1,
         warnings => [
-            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\./,
+            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\.?/,
         ],
     },
 
@@ -110,12 +110,12 @@ my @tests = (
     {   cmd  => [ checkout => 'does-not-exist', { fatal => [1] } ],
         exit => 1,
         dollar_at =>
-            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\./,
+            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\.?/,
     },
     {   cmd  => [ checkout => 'does-not-exist', { fatal => 1 } ],
         exit => 1,
         dollar_at =>
-            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\./,
+            qr/^error: pathspec 'does-not-exist' did not match any file\(s\) known to git\.?/,
     },
     {   cmd      => [ rm => 'does-not-exist', { fatal => -128 } ],
         exit     => 128,


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Git-Repository.
We thought you might be interested in it too.

    Description: git 2.19 apparently changed its error messages.
     Make the trailing dot optional so tests pass with < 2.19 and >= 2.19.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-08-29
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libgit-repository-perl/raw/master/debian/patches/git-2.19-errors.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
