### PR TITLE
Silence the new init hint in git 2.30.

### DIFF
--- a/t/24-errors.t
+++ b/t/24-errors.t
@@ -57,7 +57,7 @@ local $SIG{__WARN__} = sub { push @warnings, shift };
 my @tests = (
 
     # empty repository
-    {   test_repo => [],
+    {   test_repo => [ init => [ '-q' ] ],
         cmd       => [qw( log -1 )],
         exit      => 128,
         dollar_at => qr/^fatal: (?:bad default revision 'HEAD' |your current branch 'master' does not have any commits yet)/,
@@ -142,7 +142,7 @@ push @tests, (
 
     # setup a repo with some 'fatal' options
     # and override them in the call to run()
-    {   test_repo => [ git    => { fatal      => [ 1 .. 255 ] } ],
+    {   test_repo => [ init => [ '-q' ], git    => { fatal      => [ 1 .. 255 ] } ],
         cmd       => [ exit => 125, { git => $exit } ],
         exit      => 125,
         dollar_at => qr/^fatal: unknown git error/,
@@ -157,7 +157,7 @@ push @tests, (
 push @tests, (
 
     # FATALITY
-    {   test_repo => [ git => { fatal => [ 0 .. 255 ] } ],
+    {   test_repo => [ init => [ '-q' ], git => { fatal => [ 0 .. 255 ] } ],
         cmd       => ['version'],
         exit      => 0,
         dollar_at => qr/^fatal: unknown git error/,
@@ -172,12 +172,12 @@ push @tests, (
 push @tests, (
 
     # "!0" is a shortcut for 1..255
-    {   test_repo => [],
+    {   test_repo => [ init => [ '-q' ] ],
         cmd       => [ exit => 140, { git => $exit, fatal => '!0' } ],
         exit      => 140,
         dollar_at => qr/^fatal: unknown git error/,
     },
-    {   test_repo => [ git => { fatal => '!0' } ],
+    {   test_repo => [ init => [ '-q' ], git => { fatal => '!0' } ],
         cmd       => [ exit => 141, { git => $exit } ],
         exit      => 141,
         dollar_at => qr/^fatal: unknown git error/,


### PR DESCRIPTION
With git 2.30, there are now hints about `init.defaultBranch` value change that propagate as warnings. I was looking for quick fix to silence those hints/warnings, so here's first draft. Ideally we might want to just set the `init.defaultBranch` for the tests (in `test_repository`) or something similar but I was not sure what your plans were.

Addressing
```
t/24-errors.t .............. 
1..65
ok 1 - log -1: died
ok 2 - log -1: exit status 128
not ok 3 - warnings: 0

#   Failed test 'warnings: 0'
#   at t/24-errors.t line 214.
#          got: '1'
#     expected: '0'
# hint: Using 'master' as the name for the initial branch. This default branch name
# hint: is subject to change. To configure the initial branch name to use in all
[...]
Test Summary Report
-------------------
t/24-errors.t            (Wstat: 1280 Tests: 65 Failed: 5)
  Failed tests:  3, 47, 53, 59, 62
  Non-zero exit status: 5
Files=21, Tests=567,  3 wallclock secs ( 0.08 usr  0.02 sys +  1.78 cusr  1.05 csys =  2.93 CPU)
Result: FAIL
```