### PR TITLE
Add input_record_separator option to Git::Repository::Command::new

### DIFF
--- a/lib/Git/Repository/Command.pm
+++ b/lib/Git/Repository/Command.pm
@@ -174,9 +174,13 @@ sub final_output {
     my ($self, @cb) = @_;
 
     # get output / errput
+    my $input_record_separator =
+        exists $self->options->{input_record_separator}
+        ? $self->options->{input_record_separator}
+        : "\n";
     my ( @output, @errput );
     $self->loop_on(
-        input_record_separator => "\n",
+        input_record_separator => $input_record_separator,
         stdout => sub { chomp( my $o = shift ); push @output, $o; },
         stderr => sub { chomp( my $e = shift ); push @errput, $e; },
     );
@@ -332,6 +336,20 @@ Boolean option to control the output of warnings.
 
 If true, methods such as C<final_output()> will not warn when Git outputs
 messages on C<STDERR>.
+
+=item C<input_record_separator>
+
+A string which the C<$/> special variable is set to during the command
+execution.
+
+This is mostly useful when passing the C<-z> option to a Git command so that it
+output lines separated by the NUL character and you want to get it line by line,
+like this:
+
+    my @files = $git->run(
+        qw/ls-tree -r --name-only -z HEAD/,
+        { input_record_separator => "\0" },
+    );
 
 =back
 

--- a/t/20-simple.t
+++ b/t/20-simple.t
@@ -365,3 +365,10 @@ ok( $r = eval { Git::Repository->new( work_tree => $dir ) },
 $tree = $r->run( mktree => { input => '' } );
 is( $tree, '4b825dc642cb6eb9a060e54bf8d69288fbee4904', 'mktree empty tree' );
 
+# use ls-tree with input_record_separator option
+BEGIN { $tests += 1 }
+my @files = $r->run(
+    qw/ls-tree --name-only -z HEAD/,
+    { input_record_separator => "\0" },
+);
+ok( @files > 1, 'option input_record_separator in run() worked');


### PR DESCRIPTION
This option specifies a string which the $/ special variable is set to
during the command execution.

This allows one to read line by line the output of Git commands when
passing the -z option to them. One only needs to specify the "\0" string
as the input_record_separator.

This implements RT #134239.