### PR TITLE
Workaround change of behaviour in git 2.38.1 for CVE-2022-39253.

### DIFF
--- a/t/21-submodule.t
+++ b/t/21-submodule.t
@@ -44,6 +44,7 @@ $s->run( checkout => 'master', { quiet => 1 } );
 # now test adding a submodule
 my $r = test_repository(@init);
 $r->run(
+    ( Git::Repository->version_ge('2.38.1') ? ('-c', 'protocol.file.allow=always') : ()),
     submodule => add => $s->work_tree => 'sub',
     { env => { GIT_WORK_TREE => undef } }
 );


### PR DESCRIPTION
By default, protocol.file.allow now defaults to user, preventing clones with symlinks.

https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253

Starting off with this proposal to see what approach would be deemed the best.