### PR TITLE
tests: Do not write to current working directory

### DIFF
--- a/t/05-try_git.t
+++ b/t/05-try_git.t
@@ -67,7 +67,7 @@ SKIP:
             if !eval { symlink( '', '' ); 1 };
 
         # a place to experiment
-        my $dir = tempdir( DIR => 't', CLEANUP => 1 );
+        my $dir = tempdir( CLEANUP => 1 );
         my $target = File::Spec->catfile( $dir, 'target' );
         my $link   = File::Spec->catfile( $dir, 'link' );
         my $real   = File::Spec->catfile( $dir, 'real' );


### PR DESCRIPTION
Fedora installs tests to validate the installed modules later. The intallation location for the tests is read only. Git-Repository tests already utilize File::Temp to use a proper temporary directory. The only exception was t/05-try_git.t:

    Error in tempdir() using t/XXXXXXXXXX: Could not create directory t/FHkns_IVOr: Permission denied at t/05-try_git.t line 71.
    # Looks like your test exited with 13 just after 20.
    t/05-try_git.t ............. Dubious, test returned 13 (wstat 3328, 0xd00)
    Failed 16/36 subtests

This patch fixes the test to prefer a platform-provided location for temporary files (e.g. /tmp) over the current working directory.